### PR TITLE
remove set -u for unset variables

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -euo pipefail
+
+set -e
+set -o pipefail
 
 install_helmsops() {
   local install_type=$1


### PR DESCRIPTION
I ran into problems that I didn't run into with asdf-clisso, with TMPDIR not being set. This removes set -u and formats it the same as asdf-clisso: https://github.com/spothero/asdf-clisso/blob/main/bin/install#L1-L5